### PR TITLE
used `implementation` in gradle instead of `compile`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,26 +43,27 @@ repositories {
 }
 
 dependencies {
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.1'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.1'
     //compile group: 'pw.chew', name: 'jda-chewtils-commons', version: '2.0-SNAPSHOT'
     //compile group: 'pw.chew', name: 'jda-chewtils-menu', version: '2.0-SNAPSHOT'
-    compile group: 'com.github.Andre601', name: 'JDA-Chewtils', version: '9513237948'
-    compile group: 'com.rethinkdb', name: 'rethinkdb-driver', version:'2.4.4'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
-    compile group: 'com.github.DV8FromTheWorld', name: 'JDA', version: 'e111d55'
-    //compile(group: 'net.dv8tion', name: 'JDA', version:'5.0.0-alpha.17'){
+    implementation group: 'com.github.Andre601', name: 'JDA-Chewtils', version: '9513237948'
+    implementation group: 'com.rethinkdb', name: 'rethinkdb-driver', version:'2.4.4'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
+    // implementation group: 'com.github.DV8FromTheWorld', name: 'JDA', version: 'e111d55'
+    implementation group: 'net.dv8tion', name: 'JDA', version:'5.0.0-alpha.18'
+    //{
     //    exclude(module: 'opus-java')
     //}
-    compile group: 'club.minnced', name: 'discord-webhooks', version: '0.8.2'
-    compile group: 'commons-io', name: 'commons-io', version: '2.11.0'
-    compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    compile group: 'com.mashape.unirest', name: 'unirest-java', version: '1.4.9'
-    compile group: 'com.github.rainestormee', name: 'jda-command', version: '1.1.5'
-    compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.1'
-    compile group: 'org.projectlombok', name: 'lombok', version: '1.18.24'
-    compile group: 'io.javalin', name: 'javalin', version: '4.6.4'
-    compile group: 'org.json', name: 'json', version: '20220924'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0'
+    implementation group: 'club.minnced', name: 'discord-webhooks', version: '0.8.2'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+    implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
+    implementation group: 'com.mashape.unirest', name: 'unirest-java', version: '1.4.9'
+    implementation group: 'com.github.rainestormee', name: 'jda-command', version: '1.1.5'
+    implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.1'
+    implementation group: 'org.projectlombok', name: 'lombok', version: '1.18.24'
+    implementation group: 'io.javalin', name: 'javalin', version: '4.6.4'
+    implementation group: 'org.json', name: 'json', version: '20220924'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0'
 }
 
 compileJava {


### PR DESCRIPTION
The `compile` keyword is deprecated and removed in the latest version of Gradles, instead we can use `implementation`